### PR TITLE
Refactor: Remove processor_factory from DAG processing (#16659)

### DIFF
--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -43,7 +43,6 @@ from airflow.dag_processing.manager import (
 )
 from airflow.dag_processing.processor import DagFileProcessorProcess
 from airflow.jobs.local_task_job import LocalTaskJob as LJ
-from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import DagBag, DagModel, TaskInstance as TI
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance
@@ -93,12 +92,12 @@ class FakeDagFileProcessorRunner(DagFileProcessorProcess):
         return self._result
 
     @staticmethod
-    def _fake_dag_processor_factory(file_path, callbacks, dag_ids, pickle_dags):
+    def _create_process(file_path, callback_requests, dag_ids, pickle_dags):
         return FakeDagFileProcessorRunner(
             file_path,
             pickle_dags,
             dag_ids,
-            callbacks,
+            callback_requests,
         )
 
     @property
@@ -137,7 +136,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
             manager = DagFileProcessorManager(
                 dag_directory=dags_folder,
                 max_runs=1,
-                processor_factory=FakeDagFileProcessorRunner._fake_dag_processor_factory,
                 processor_timeout=timedelta.max,
                 signal_conn=child_pipe,
                 dag_ids=[],
@@ -155,11 +153,9 @@ class TestDagFileProcessorManager(unittest.TestCase):
         Test that when a processor already exist with a filepath, a new processor won't be created
         with that filepath. The filepath will just be removed from the list.
         """
-        processor_factory_mock = MagicMock()
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=processor_factory_mock,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -182,7 +178,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         # and since a processor with 'file_1' already exists,
         # even though it is first in '_file_path_queue'
         # a new processor is created with 'file_2' and not 'file_1'.
-        processor_factory_mock.assert_called_once_with('file_2.py', [], [], False)
 
         assert file_1 in manager._processors.keys()
         assert file_2 in manager._processors.keys()
@@ -192,7 +187,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -214,7 +208,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -246,7 +239,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -274,7 +266,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -313,7 +304,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -347,7 +337,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=3,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -389,7 +378,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -432,7 +420,10 @@ class TestDagFileProcessorManager(unittest.TestCase):
             session.query(TI).delete()
             session.query(LJ).delete()
 
-    def test_handle_failure_callback_with_zombies_are_correctly_passed_to_dag_file_processor(self):
+    @mock.patch('airflow.dag_processing.manager.DagFileProcessorProcess')
+    def test_handle_failure_callback_with_zombies_are_correctly_passed_to_dag_file_processor(
+        self, mock_processor
+    ):
         """
         Check that the same set of failure callback with zombies are passed to the dag
         file processors until the next zombie detection logic is invoked.
@@ -473,16 +464,17 @@ class TestDagFileProcessorManager(unittest.TestCase):
 
             fake_processors = []
 
-            def fake_processor_factory(*args, **kwargs):
+            def fake_processor_(*args, **kwargs):
                 nonlocal fake_processors
-                processor = FakeDagFileProcessorRunner._fake_dag_processor_factory(*args, **kwargs)
+                processor = FakeDagFileProcessorRunner._create_process(*args, **kwargs)
                 fake_processors.append(processor)
                 return processor
+
+            mock_processor.side_effect = fake_processor_
 
             manager = DagFileProcessorManager(
                 dag_directory=test_dag_path,
                 max_runs=1,
-                processor_factory=fake_processor_factory,
                 processor_timeout=timedelta.max,
                 signal_conn=child_pipe,
                 dag_ids=[],
@@ -516,7 +508,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta(seconds=5),
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -537,7 +528,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         manager = DagFileProcessorManager(
             dag_directory='directory',
             max_runs=1,
-            processor_factory=MagicMock().return_value,
             processor_timeout=timedelta(seconds=5),
             signal_conn=MagicMock(),
             dag_ids=[],
@@ -558,10 +548,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
         Test to check that a DAG with a system.exit() doesn't break the scheduler.
         """
 
-        # We need to _actually_ parse the files here to test the behaviour.
-        # Right now the parsing code lives in SchedulerJob, even though it's
-        # called via utils.dag_processing.
-
         dag_id = 'exit_test_dag'
         dag_directory = TEST_DAG_FOLDER.parent / 'dags_with_system_exit'
 
@@ -575,7 +561,6 @@ class TestDagFileProcessorManager(unittest.TestCase):
             dag_directory=dag_directory,
             dag_ids=[],
             max_runs=1,
-            processor_factory=SchedulerJob._create_dag_file_processor,
             processor_timeout=timedelta(seconds=5),
             signal_conn=child_pipe,
             pickle_dags=False,
@@ -599,7 +584,8 @@ class TestDagFileProcessorManager(unittest.TestCase):
     @conf_vars({('core', 'load_examples'): 'False'})
     @pytest.mark.backend("mysql", "postgres")
     @pytest.mark.execution_timeout(30)
-    def test_pipe_full_deadlock(self):
+    @mock.patch('airflow.dag_processing.manager.DagFileProcessorProcess')
+    def test_pipe_full_deadlock(self, mock_processor):
         dag_filepath = TEST_DAG_FOLDER / "test_scheduler_dags.py"
 
         child_pipe, parent_pipe = multiprocessing.Pipe()
@@ -638,18 +624,19 @@ class TestDagFileProcessorManager(unittest.TestCase):
 
         fake_processors = []
 
-        def fake_processor_factory(*args, **kwargs):
+        def fake_processor_(*args, **kwargs):
             nonlocal fake_processors
-            processor = FakeDagFileProcessorRunner._fake_dag_processor_factory(*args, **kwargs)
+            processor = FakeDagFileProcessorRunner._create_process(*args, **kwargs)
             fake_processors.append(processor)
             return processor
+
+        mock_processor.side_effect = fake_processor_
 
         manager = DagFileProcessorManager(
             dag_directory=dag_filepath,
             dag_ids=[],
             # A reasonable large number to ensure that we trigger the deadlock
             max_runs=100,
-            processor_factory=fake_processor_factory,
             processor_timeout=timedelta(seconds=5),
             signal_conn=child_pipe,
             pickle_dags=False,
@@ -708,9 +695,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                 pass
 
             # Starting dag processing with 0 max_runs to avoid redundant operations.
-            processor_agent = DagFileProcessorAgent(
-                test_dag_path, 0, type(self)._processor_factory, timedelta.max, [], False, async_mode
-            )
+            processor_agent = DagFileProcessorAgent(test_dag_path, 0, timedelta.max, [], False, async_mode)
             processor_agent.start()
             if not async_mode:
                 processor_agent.run_single_parsing_loop()
@@ -728,9 +713,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
 
         test_dag_path = TEST_DAG_FOLDER / 'test_scheduler_dags.py'
         async_mode = 'sqlite' not in conf.get('core', 'sql_alchemy_conn')
-        processor_agent = DagFileProcessorAgent(
-            test_dag_path, 1, type(self)._processor_factory, timedelta.max, [], False, async_mode
-        )
+        processor_agent = DagFileProcessorAgent(test_dag_path, 1, timedelta.max, [], False, async_mode)
         processor_agent.start()
         if not async_mode:
             processor_agent.run_single_parsing_loop()
@@ -760,9 +743,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
             pass
 
         # Starting dag processing with 0 max_runs to avoid redundant operations.
-        processor_agent = DagFileProcessorAgent(
-            test_dag_path, 0, type(self)._processor_factory, timedelta.max, [], False, async_mode
-        )
+        processor_agent = DagFileProcessorAgent(test_dag_path, 0, timedelta.max, [], False, async_mode)
         processor_agent.start()
         if not async_mode:
             processor_agent.run_single_parsing_loop()


### PR DESCRIPTION
This change removes processor_factory that was passed around a lot
between different classes and creates the processor at the point of need

Co-authored-by: Jed Cunningham <66968678+jedcunningham@users.noreply.github.com>

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
