### PR TITLE
Fixes UI assets compilation from PROD image built from sources (#17086)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,14 +248,15 @@ ENV ADDITIONAL_PYTHON_DEPS=${ADDITIONAL_PYTHON_DEPS} \
 WORKDIR /opt/airflow
 
 # hadolint ignore=SC2086, SC2010
-RUN if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then \
-        bash /scripts/docker/install_from_docker_context_files.sh; \
-    elif [[ ${INSTALL_FROM_PYPI} == "true" ]]; then \
-        bash /scripts/docker/install_airflow.sh; \
-    else \
+RUN if [[ ${AIRFLOW_INSTALLATION_METHOD} == "." ]]; then \
         # only compile assets if the prod image is build from sources
         # otherwise they are already compiled-in
         bash /scripts/docker/compile_www_assets.sh; \
+    fi; \
+    if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then \
+        bash /scripts/docker/install_from_docker_context_files.sh; \
+    elif [[ ${INSTALL_FROM_PYPI} == "true" ]]; then \
+        bash /scripts/docker/install_airflow.sh; \
     fi; \
     if [[ -n "${ADDITIONAL_PYTHON_DEPS}" ]]; then \
         bash /scripts/docker/install_additional_dependencies.sh; \

--- a/scripts/docker/compile_www_assets.sh
+++ b/scripts/docker/compile_www_assets.sh
@@ -28,7 +28,12 @@ function compile_www_assets() {
     md5sum_file="static/dist/sum.md5"
     readonly md5sum_file
     local www_dir
-    www_dir="$(python -m site --user-site)/airflow/www"
+    if [[ ${AIRFLOW_INSTALLATION_METHOD=} == "." ]]; then
+        # In case we are building from sources in production image, we should build the assets
+        www_dir="${AIRFLOW_SOURCES_TO}/airflow/www"
+    else
+        www_dir="$(python -m site --user-site)/airflow/www"
+    fi
     pushd ${www_dir} || exit 1
     yarn install --frozen-lockfile --no-cache
     yarn run prod


### PR DESCRIPTION
The #16577 change removed yarn.lock from installed packages
and it removed the possibility of preparing assets after the
package is installed - so far that was the way it was done in
the PROD image built from sources. The asset compilation
was supposed to work after the change but it was not
performed in this case.

The change fixes it by:

* detecting properly if the PROD image is built from sources
  (INSTALLATION_METHOD)
* compiling the assets from sources, not from package
* installing airflow from sources AFTER assets were compiled

Fixes #16939

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
