### PR TITLE
ECSOperator / pass context to self.xcom_pull as it was missing (when …

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -220,7 +220,7 @@ class ECSOperator(BaseOperator):
         self.client = self.get_hook().get_conn()
 
         if self.reattach:
-            self._try_reattach_task()
+            self._try_reattach_task(context)
 
         if not self.arn:
             self._start_task(context)
@@ -301,7 +301,7 @@ class ECSOperator(BaseOperator):
             execution_date=context["ti"].execution_date,
         )
 
-    def _try_reattach_task(self):
+    def _try_reattach_task(self, context):
         task_def_resp = self.client.describe_task_definition(taskDefinition=self.task_definition)
         ecs_task_family = task_def_resp['taskDefinition']['family']
 
@@ -312,6 +312,7 @@ class ECSOperator(BaseOperator):
 
         # Check if the ECS task previously launched is already running
         previous_task_arn = self.xcom_pull(
+            context,
             task_ids=self.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.task_id),
             key=self.REATTACH_XCOM_KEY,
         )

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -80,6 +80,7 @@ class TestECSOperator(unittest.TestCase):
 
     def setUp(self):
         self.set_up_operator()
+        self.mock_context = mock.MagicMock()
 
     def test_init(self):
         assert self.ecs.region_name == 'eu-west-1'
@@ -340,7 +341,7 @@ class TestECSOperator(unittest.TestCase):
         }
 
         self.ecs.reattach = True
-        self.ecs.execute(None)
+        self.ecs.execute(self.mock_context)
 
         self.aws_hook_mock.return_value.get_conn.assert_called_once()
         extend_args = {}
@@ -357,6 +358,7 @@ class TestECSOperator(unittest.TestCase):
 
         start_mock.assert_not_called()
         xcom_pull_mock.assert_called_once_with(
+            self.mock_context,
             key=self.ecs.REATTACH_XCOM_KEY,
             task_ids=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id),
         )
@@ -389,7 +391,7 @@ class TestECSOperator(unittest.TestCase):
         client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
 
         self.ecs.reattach = True
-        self.ecs.execute(None)
+        self.ecs.execute(self.mock_context)
 
         self.aws_hook_mock.return_value.get_conn.assert_called_once()
         extend_args = {}
@@ -403,7 +405,7 @@ class TestECSOperator(unittest.TestCase):
         reattach_mock.assert_called_once()
         client_mock.run_task.assert_called_once()
         xcom_set_mock.assert_called_once_with(
-            None,
+            self.mock_context,
             key=self.ecs.REATTACH_XCOM_KEY,
             task_id=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id),
             value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55",


### PR DESCRIPTION
…using reattach) (#17141)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
